### PR TITLE
Miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ example.out
 /LootLibrary.vcxproj.user
 
 /LootLibrary
+
+# CMake
+build/
+
+# IntelliJ
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.15)
+project(loot_library.h)
+
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+if (WIN32)
+    set(CMAKE_C_FLAGS "-D_WIN32")
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -DNDEBUG")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g3 -DDEBUG")
+
+set(HEADERS
+        src/loot/loot_table_parser.h
+        src/v2/logging.h
+        src/v2/loot_functions.h
+        src/v2/loot_table_context.h
+        src/v2/mc_loot.h
+        src/v2/rng.h
+        src/v2/cjson/cJSON.h
+)
+set(SOURCES
+        src/v2/loot_functions.c
+        src/v2/loot_table_context.c
+        src/v2/loot_table_parser.c
+        src/v2/cjson/cJSON.c
+        src/examples/example_v2.c
+)
+
+add_library(objects OBJECT ${SOURCES})
+set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+add_library(loot_library.h SHARED $<TARGET_OBJECTS:objects>)
+add_library(loot_library.h_static STATIC $<TARGET_OBJECTS:objects>)
+
+if (WIN32)
+    set_target_properties(loot_library.h PROPERTIES PREFIX "")
+endif()
+
+
+install(TARGETS loot_library.h loot_library.h_static DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include)

--- a/src/v2/cjson/cJSON.h
+++ b/src/v2/cjson/cJSON.h
@@ -63,9 +63,9 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #if defined(CJSON_HIDE_SYMBOLS)
 #define CJSON_PUBLIC(type)   type CJSON_STDCALL
 #elif defined(CJSON_EXPORT_SYMBOLS)
-#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
 #elif defined(CJSON_IMPORT_SYMBOLS)
-#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
 #endif
 #else /* !__WINDOWS__ */
 #define CJSON_CDECL

--- a/src/v2/loot_functions.c
+++ b/src/v2/loot_functions.c
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
 
 // ----------------------------------------------------------------------------------------
 // the actual loot functions

--- a/src/v2/loot_functions.h
+++ b/src/v2/loot_functions.h
@@ -46,12 +46,12 @@ struct LootFunction {
 // ----------------------------------------------------------------------------------------
 // Roll count choice functions
 
-inline int roll_count_constant(uint64_t* rand, const int min, const int max)
+static inline int roll_count_constant(uint64_t* rand, const int min, const int max)
 {
 	return min;
 }
 
-inline int roll_count_uniform(uint64_t* rand, const int min, const int max)
+static inline int roll_count_uniform(uint64_t* rand, const int min, const int max)
 {
 	const int bound = max - min + 1;
 	return nextInt(rand, bound) + min;


### PR DESCRIPTION
Some miscellaneous changes.

- Added support for CMake.
- Removed `__declspec(dllexport)` in cJSON. Using this once forces all other code to use it too. If you do not add this attribute, the symbols won't be present in the DLL. Simply removing it in cJSON restores the default behaviour of including symbols.
- Fixed crashes during compilation because of a missing include and `static` modifier.
